### PR TITLE
Return structured scalar instead of tuple

### DIFF
--- a/rvg/rvg.py
+++ b/rvg/rvg.py
@@ -38,7 +38,7 @@ class NumPyRVG:
         for field_name in dtype.names:
             field_dtype = dtype[field_name] if hasattr(dtype[field_name], 'names') and dtype[field_name].names else dtype[field_name].type
             retvals.append(self(field_dtype))
-        return tuple(retvals)
+        return np.array([tuple(retvals)], dtype=dtype)[0]
 
     def __call__(self, dtype, length=0):
 

--- a/tests/test_numpyrvg.py
+++ b/tests/test_numpyrvg.py
@@ -52,7 +52,7 @@ def test_structured_dtypes():
 
         scl = rand(struct_dtype)
 
-        assert type(scl) == tuple
+        assert scl.dtype == struct_dtype
 
         arr = rand(struct_dtype, length)
 
@@ -70,23 +70,21 @@ def test_nested_structured_dtypes_simple():
     ]
 
     name = randname()
+
+    struct1 = np.dtype([(name + '1', dtypes[0][0]), (name + '2', dtypes[0][1])])
+    struct2 = np.dtype([(name + '3', dtypes[1][0]), (name + '4', dtypes[1][1])])
+    struct3 = np.dtype([(name + '5', dtypes[2][0]), (name + '6', dtypes[2][1])])
+
     nested_struct_dtype_simple = np.dtype([
-        ('struct1', np.dtype([(name + '1', dtypes[0][0]), (name + '2', dtypes[0][1])])),
-        ('struct2', np.dtype([(name + '3', dtypes[1][0]), (name + '4', dtypes[1][1])])),
-        ('struct3', np.dtype([(name + '5', dtypes[2][0]), (name + '6', dtypes[2][1])])),
+        ('struct1', struct1),
+        ('struct2', struct2),
+        ('struct3', struct3),
     ])
 
     val = rand(nested_struct_dtype_simple)
 
-    # outer struct properties
-    assert type(val) == tuple and len(val) == 3
-    # inner structs properties
-    assert type(val[0]) == tuple and len(val[0]) == 2
-    assert type(val[0][0]) == dtypes[0][0] and type(val[0][1]) == dtypes[0][1]
-    assert type(val[1]) == tuple and len(val[1]) == 2
-    assert type(val[1][0]) == dtypes[1][0] and type(val[1][1]) == dtypes[1][1]
-    assert type(val[2]) == tuple and len(val[2]) == 2
-    assert type(val[2][0]) == dtypes[2][0] and type(val[2][1]) == dtypes[2][1]
+    # recursive structural equality check
+    assert val.dtype == nested_struct_dtype_simple and len(val) == 3
 
 def test_nested_structured_dtypes():
     rand = NumPyRVG(1000)


### PR DESCRIPTION
Patched rand_val_for_non_primitive_type so that structured scalars are returned instead of tuples. Relevant tests modified to reflect changes.